### PR TITLE
Some improvements (?) to email sig stripping

### DIFF
--- a/includes/bp-rbe-functions.php
+++ b/includes/bp-rbe-functions.php
@@ -335,7 +335,7 @@ function bp_rbe_log( $message ) {
  * @since 1.0-beta
  */
 function bp_rbe_get_last_line( $text ) {
-	return substr( strrchr( $text, 10 ), 1 );
+	return trim( substr( strrchr( $text, 10 ), 1 ) );
 }
 
 /** Hook-related ********************************************************/
@@ -422,7 +422,7 @@ function bp_rbe_remove_email_client_signature( $content ) {
 		// remove common mobile device sigs
 		// is this string localized in other countries? better safe than sorry!
 		case strpos( $last_line, __( 'Sent from my ', 'bp-rbe' ) ) === 0 :
-			$content = rtrim( $content, PHP_EOL . $last_line );
+			$content = substr( $content, 0, strrpos( $content, 10 ) );
 
 			break;
 
@@ -431,7 +431,7 @@ function bp_rbe_remove_email_client_signature( $content ) {
 		// eg. 'On DATE, USER wrote:'
 		//     'USER wrote:'
 		case substr( $last_line, -1 ) === ':' :
-			$content = rtrim( $content, PHP_EOL . $last_line );
+			$content = substr( $content, 0, strrpos( $content, 10 ) );
 
 			break;
 	}


### PR DESCRIPTION
See #6. I was messing with this on cdev, because my own (Thunderbird, OSX) signature/reply-prefix wasn't getting stripped correctly. I found that making two key changes made it work:
- Trim the return value of `bp_rbe_get_last_line()`. In my case, a stray EOL was slipping through, which meant that when you checked to see whether the last character `=== ':'`, it wasn't working
- When actually stripping that last line in `bp_rbe_remove_email_client_signature()`, use a similar technique to determine the last line to what is used in `bp_rbe_get_last_line()`. Without this change, I was successfully falling through to `case substr( $last_line, -1 ) === ':' :`, but your technique that used `PHP_EOL` wasn't matching correctly, so that nothing got stripped. This could be an issue with my client, or with your use of `PHP_EOL`, but in any case, I think it makes sense to determine the last line of the message in a consistent way in both functions (and the way used in this pull request actually works for me, so bonus :) )

Sending as a pull request rather than a committed changeset because I have done far less work with this kind of email parsing than you, and I want you to make sure that it's non-destructive before applying it. (They both seem OK to me, fwiw)
